### PR TITLE
Impossible to build debian package for armhf architecture #1026

### DIFF
--- a/src/extract-from-package.mjs
+++ b/src/extract-from-package.mjs
@@ -140,7 +140,8 @@ export async function extractFromPackage(json, dir) {
   processPkg(json, dir);
 
   if (arch.size > 0) {
-    properties.arch = [...arch].filter(a => a === npmArchMapping[hostArch]);
+    const mappedArch = [...arch].filter(a => a === npmArchMapping[hostArch])
+    properties.arch = mappedArch.length > 0 ? mappedArch : Array.from(arch).slice(0,1);
   }
 
   return { properties, sources, dependencies, output };


### PR DESCRIPTION
Proposition to fix #1026 that works for me. If mapping is not successful it takes first architecture from provided configuration.
