### PR TITLE
Fixed situation, when property used more than once in postinstall hook

### DIFF
--- a/src/output/debian.mjs
+++ b/src/output/debian.mjs
@@ -85,8 +85,8 @@ export class DEBIAN extends Packager {
         if (name) {
           yield new StringContentEntry(
             name,
-            f.body.replace(
-              /\{\{(\w+)\}\}/m,
+            f.body.replaceAll(
+              /\{\{(\w+)\}\}/mg,
               (match, key, offset, string) =>
                 properties[key] || "{{" + key + "}}"
             )


### PR DESCRIPTION
When we use {{property}} in post-install, Debian installation substitutes only the first entrance of the property in the hooks.

The proposed path fixes this.